### PR TITLE
chore: bump node 14.x to latest 14.17.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add log output to help explain your problem.
+
+**Platform (please complete the following information):**
+ - OS: [e.g. Linux x86, Linux ARM, Mac x86, Mac M1, Windows]
+
+**Additional context**
+Add any other context about the problem here.

--- a/al2/aarch64/standard/2.0/Dockerfile
+++ b/al2/aarch64/standard/2.0/Dockerfile
@@ -222,7 +222,7 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_10_VERSION="10.21.0"
+ENV NODE_10_VERSION="10.24.1"
 
 RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
@@ -361,7 +361,7 @@ RUN set -ex \
     && docker-compose version
 
 # Node 12
-ENV NODE_12_VERSION="12.18.0"
+ENV NODE_12_VERSION="12.22.2"
 
 RUN  n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && rm -rf /tmp/*
@@ -416,5 +416,4 @@ COPY amazon-ssm-agent.json          /etc/amazon/ssm/
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 
 #=======================End of layer: aarch64_v2  =================
-
 

--- a/al2/x86_64/standard/3.0/Dockerfile
+++ b/al2/x86_64/standard/3.0/Dockerfile
@@ -297,7 +297,7 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_10_VERSION="10.23.0"
+ENV NODE_10_VERSION="10.24.1"
 
 RUN  n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
@@ -398,7 +398,7 @@ RUN set -ex \
     && pip3 install --no-cache-dir --upgrade setuptools wheel aws-sam-cli awscli boto3 pipenv virtualenv --use-feature=2020-resolver
 
 # Node 12
-ENV NODE_12_VERSION="12.19.1"
+ENV NODE_12_VERSION="12.22.2"
 
 RUN  n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && rm -rf /tmp/*
@@ -463,4 +463,3 @@ COPY amazon-ssm-agent.json          /etc/amazon/ssm/
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 
 #=======================End of layer: al2_v3  =================
-

--- a/ubuntu/standard/4.0/Dockerfile
+++ b/ubuntu/standard/4.0/Dockerfile
@@ -217,8 +217,9 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_12_VERSION="12.19.1" \
-    NODE_10_VERSION="10.23.0"
+
+ENV NODE_12_VERSION="12.22.2" \
+    NODE_10_VERSION="10.24.1"
 
 RUN     n $NODE_10_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -201,7 +201,7 @@ RUN set -ex \
 
 #****************      NODEJS     ****************************************************
 
-ENV NODE_12_VERSION="12.20.1"
+ENV NODE_12_VERSION="12.22.2"
 ENV NODE_14_VERSION="14.17.2"
 
 RUN     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \

--- a/ubuntu/standard/5.0/Dockerfile
+++ b/ubuntu/standard/5.0/Dockerfile
@@ -202,7 +202,7 @@ RUN set -ex \
 #****************      NODEJS     ****************************************************
 
 ENV NODE_12_VERSION="12.20.1"
-ENV NODE_14_VERSION="14.15.4"
+ENV NODE_14_VERSION="14.17.2"
 
 RUN     n $NODE_14_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \
      && n $NODE_12_VERSION && npm install --save-dev -g -f grunt && npm install --save-dev -g -f grunt-cli && npm install --save-dev -g -f webpack \


### PR DESCRIPTION
*Issue #, if available:*
Blog post on July 2021 Security Releases: nodejs.org/en/blog/vulnerability/july-2021-security-releases

*Description of changes:*
bump node 14.x to latest 14.17.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
